### PR TITLE
Support for esp link wifi serial bridge

### DIFF
--- a/MemcardRex/GUI/cardReaderWindow.cs
+++ b/MemcardRex/GUI/cardReaderWindow.cs
@@ -124,10 +124,19 @@ namespace MemcardRex
         }
 
         //Read a Memory Card from PS1CardLink
-        public byte[] readMemoryCardPS1CLnk(Form hostWindow, string applicationName, string comPort)
+        public byte[] readMemoryCardPS1CLnk(Form hostWindow, string applicationName, string comPort, string remoteAddress, int remotePort)
         {
+            string errorString;
+
             //Initialize PS1CardLink
-            string errorString = PS1CLnk.StartPS1CardLink(comPort);
+            if (remoteAddress.Length > 0)
+            {
+                errorString = PS1CLnk.StartPS1CardLink(remoteAddress, remotePort);
+            }
+            else
+            {
+                errorString = PS1CLnk.StartPS1CardLink(comPort);
+            }
 
             //Check if there were any errors
             if (errorString != null)
@@ -280,10 +289,20 @@ namespace MemcardRex
         }
 
         //Write a Memory Card to PS1CardLink
-        public void writeMemoryCardPS1CLnk(Form hostWindow, string applicationName, string comPort, byte[] memoryCardData, int frameNumber)
+        public void writeMemoryCardPS1CLnk(Form hostWindow, string applicationName, string comPort, string remoteAddress, int remotePort, byte[] memoryCardData, int frameNumber)
         {
             //Initialize PS1CardLink
-            string errorString = PS1CLnk.StartPS1CardLink(comPort);
+            string errorString;
+
+            if (remoteAddress.Length > 0)
+            {
+                errorString = PS1CLnk.StartPS1CardLink(remoteAddress, remotePort);
+            }
+            else
+            {
+                errorString = PS1CLnk.StartPS1CardLink(comPort);
+            }
+
 
             //Check if there were any errors
             if (errorString != null)

--- a/MemcardRex/GUI/mainWindow.Designer.cs
+++ b/MemcardRex/GUI/mainWindow.Designer.cs
@@ -67,6 +67,7 @@
             this.memCARDuinoMenuRead = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem18 = new System.Windows.Forms.ToolStripSeparator();
             this.pS1CardLinkMenuRead = new System.Windows.Forms.ToolStripMenuItem();
+            this.pS1CardLinkRemoteMenuRead = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem16 = new System.Windows.Forms.ToolStripSeparator();
             this.pS3MemoryCardAdaptorMenuRead = new System.Windows.Forms.ToolStripMenuItem();
             this.writeToToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -132,6 +133,8 @@
             this.saveInformationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.pS1CardLinkRemoteMenuWrite = new System.Windows.Forms.ToolStripMenuItem();
+            this.pS1CardLinkRemoteMenuFormat = new System.Windows.Forms.ToolStripMenuItem();
             dexDriveMenuFormat = new System.Windows.Forms.ToolStripMenuItem();
             this.mainMenu.SuspendLayout();
             this.mainToolbar.SuspendLayout();
@@ -142,7 +145,7 @@
             // dexDriveMenuFormat
             // 
             dexDriveMenuFormat.Name = "dexDriveMenuFormat";
-            dexDriveMenuFormat.Size = new System.Drawing.Size(215, 22);
+            dexDriveMenuFormat.Size = new System.Drawing.Size(266, 22);
             dexDriveMenuFormat.Text = "DexDrive";
             dexDriveMenuFormat.Click += new System.EventHandler(this.dexDriveMenuFormat_Click);
             // 
@@ -183,7 +186,7 @@
             this.newToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.newcard;
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
             this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.newToolStripMenuItem.Text = "New";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
@@ -192,7 +195,7 @@
             this.openToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.opencard;
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.openToolStripMenuItem.Text = "Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -200,49 +203,49 @@
             // 
             this.closeToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.closecard;
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.closeToolStripMenuItem.Text = "Close";
             this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
             // 
             // closeAllToolStripMenuItem
             // 
             this.closeAllToolStripMenuItem.Name = "closeAllToolStripMenuItem";
-            this.closeAllToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.closeAllToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.closeAllToolStripMenuItem.Text = "Close All";
             this.closeAllToolStripMenuItem.Click += new System.EventHandler(this.closeAllToolStripMenuItem_Click);
             // 
             // toolStripMenuItem3
             // 
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(152, 6);
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(160, 6);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.savecard;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.saveAsToolStripMenuItem.Text = "Save as...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(152, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(160, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.quiticon;
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
             this.exitToolStripMenuItem.Text = "Quit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -274,7 +277,7 @@
             // 
             this.editSaveHeaderToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.headeredit;
             this.editSaveHeaderToolStripMenuItem.Name = "editSaveHeaderToolStripMenuItem";
-            this.editSaveHeaderToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.editSaveHeaderToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.editSaveHeaderToolStripMenuItem.Text = "Edit save header...";
             this.editSaveHeaderToolStripMenuItem.Click += new System.EventHandler(this.editSaveHeaderToolStripMenuItem_Click);
             // 
@@ -282,7 +285,7 @@
             // 
             this.editSaveCommentToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.comments;
             this.editSaveCommentToolStripMenuItem.Name = "editSaveCommentToolStripMenuItem";
-            this.editSaveCommentToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.editSaveCommentToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.editSaveCommentToolStripMenuItem.Text = "Edit save comment...";
             this.editSaveCommentToolStripMenuItem.Click += new System.EventHandler(this.editSaveCommentToolStripMenuItem_Click);
             // 
@@ -291,7 +294,7 @@
             this.editWithPluginToolStripMenuItem1.Enabled = false;
             this.editWithPluginToolStripMenuItem1.Image = global::MemcardRex.Properties.Resources.plugin;
             this.editWithPluginToolStripMenuItem1.Name = "editWithPluginToolStripMenuItem1";
-            this.editWithPluginToolStripMenuItem1.Size = new System.Drawing.Size(264, 22);
+            this.editWithPluginToolStripMenuItem1.Size = new System.Drawing.Size(272, 22);
             this.editWithPluginToolStripMenuItem1.Text = "Edit with plugin";
             this.editWithPluginToolStripMenuItem1.DropDownClosed += new System.EventHandler(this.editWithPluginToolStripMenuItem_DropDownClosed);
             this.editWithPluginToolStripMenuItem1.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.editWithPluginToolStripMenuItem_DropDownItemClicked);
@@ -299,45 +302,45 @@
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(261, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(269, 6);
             // 
             // compareWithTempBufferToolStripMenuItem
             // 
             this.compareWithTempBufferToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.comparetemp;
             this.compareWithTempBufferToolStripMenuItem.Name = "compareWithTempBufferToolStripMenuItem";
-            this.compareWithTempBufferToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.compareWithTempBufferToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.compareWithTempBufferToolStripMenuItem.Text = "Compare with temp buffer";
             this.compareWithTempBufferToolStripMenuItem.Click += new System.EventHandler(this.compareWithTempBufferToolStripMenuItem_Click);
             // 
             // toolStripMenuItem13
             // 
             this.toolStripMenuItem13.Name = "toolStripMenuItem13";
-            this.toolStripMenuItem13.Size = new System.Drawing.Size(261, 6);
+            this.toolStripMenuItem13.Size = new System.Drawing.Size(269, 6);
             // 
             // editIconToolStripMenuItem
             // 
             this.editIconToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.iconedit;
             this.editIconToolStripMenuItem.Name = "editIconToolStripMenuItem";
-            this.editIconToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.editIconToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.editIconToolStripMenuItem.Text = "Edit icon...";
             this.editIconToolStripMenuItem.Click += new System.EventHandler(this.editIconToolStripMenuItem_Click);
             // 
             // toolStripMenuItem4
             // 
             this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(261, 6);
+            this.toolStripMenuItem4.Size = new System.Drawing.Size(269, 6);
             // 
             // deleteSaveToolStripMenuItem
             // 
             this.deleteSaveToolStripMenuItem.Name = "deleteSaveToolStripMenuItem";
-            this.deleteSaveToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.deleteSaveToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.deleteSaveToolStripMenuItem.Text = "Delete save";
             this.deleteSaveToolStripMenuItem.Click += new System.EventHandler(this.deleteSaveToolStripMenuItem_Click);
             // 
             // restoreSaveToolStripMenuItem
             // 
             this.restoreSaveToolStripMenuItem.Name = "restoreSaveToolStripMenuItem";
-            this.restoreSaveToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.restoreSaveToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.restoreSaveToolStripMenuItem.Text = "Restore save";
             this.restoreSaveToolStripMenuItem.Click += new System.EventHandler(this.restoreSaveToolStripMenuItem_Click);
             // 
@@ -345,20 +348,20 @@
             // 
             this.removeSaveformatSlotsToolStripMenuItem.Name = "removeSaveformatSlotsToolStripMenuItem";
             this.removeSaveformatSlotsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-            this.removeSaveformatSlotsToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.removeSaveformatSlotsToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.removeSaveformatSlotsToolStripMenuItem.Text = "Remove save (format slot(s))";
             this.removeSaveformatSlotsToolStripMenuItem.Click += new System.EventHandler(this.removeSaveformatSlotsToolStripMenuItem_Click);
             // 
             // toolStripMenuItem5
             // 
             this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(261, 6);
+            this.toolStripMenuItem5.Size = new System.Drawing.Size(269, 6);
             // 
             // copySaveToTempraryBufferToolStripMenuItem
             // 
             this.copySaveToTempraryBufferToolStripMenuItem.Name = "copySaveToTempraryBufferToolStripMenuItem";
             this.copySaveToTempraryBufferToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copySaveToTempraryBufferToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.copySaveToTempraryBufferToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.copySaveToTempraryBufferToolStripMenuItem.Text = "Copy save to temp buffer";
             this.copySaveToTempraryBufferToolStripMenuItem.Click += new System.EventHandler(this.copySaveToTempraryBufferToolStripMenuItem_Click);
             // 
@@ -366,20 +369,20 @@
             // 
             this.pasteSaveFromTemporaryBufferToolStripMenuItem.Name = "pasteSaveFromTemporaryBufferToolStripMenuItem";
             this.pasteSaveFromTemporaryBufferToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteSaveFromTemporaryBufferToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.pasteSaveFromTemporaryBufferToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.pasteSaveFromTemporaryBufferToolStripMenuItem.Text = "Paste save from temp buffer";
             this.pasteSaveFromTemporaryBufferToolStripMenuItem.Click += new System.EventHandler(this.pasteSaveFromTemporaryBufferToolStripMenuItem_Click);
             // 
             // toolStripMenuItem6
             // 
             this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-            this.toolStripMenuItem6.Size = new System.Drawing.Size(261, 6);
+            this.toolStripMenuItem6.Size = new System.Drawing.Size(269, 6);
             // 
             // importSaveToolStripMenuItem
             // 
             this.importSaveToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.importsave;
             this.importSaveToolStripMenuItem.Name = "importSaveToolStripMenuItem";
-            this.importSaveToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.importSaveToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.importSaveToolStripMenuItem.Text = "Import save...";
             this.importSaveToolStripMenuItem.Click += new System.EventHandler(this.importSaveToolStripMenuItem_Click);
             // 
@@ -387,7 +390,7 @@
             // 
             this.exportSaveToolStripMenuItem.Image = global::MemcardRex.Properties.Resources.exportsave;
             this.exportSaveToolStripMenuItem.Name = "exportSaveToolStripMenuItem";
-            this.exportSaveToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.exportSaveToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.exportSaveToolStripMenuItem.Text = "Export save...";
             this.exportSaveToolStripMenuItem.Click += new System.EventHandler(this.exportSaveToolStripMenuItem_Click);
             // 
@@ -410,52 +413,60 @@
             this.memCARDuinoMenuRead,
             this.toolStripMenuItem18,
             this.pS1CardLinkMenuRead,
+            this.pS1CardLinkRemoteMenuRead,
             this.toolStripMenuItem16,
             this.pS3MemoryCardAdaptorMenuRead});
             this.readFromToolStripMenuItem.Name = "readFromToolStripMenuItem";
-            this.readFromToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.readFromToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.readFromToolStripMenuItem.Text = "Read save data";
             // 
             // dexDriveMenuRead
             // 
             this.dexDriveMenuRead.Name = "dexDriveMenuRead";
-            this.dexDriveMenuRead.Size = new System.Drawing.Size(215, 22);
+            this.dexDriveMenuRead.Size = new System.Drawing.Size(266, 22);
             this.dexDriveMenuRead.Text = "DexDrive";
             this.dexDriveMenuRead.Click += new System.EventHandler(this.dexDriveMenuRead_Click);
             // 
             // toolStripMenuItem17
             // 
             this.toolStripMenuItem17.Name = "toolStripMenuItem17";
-            this.toolStripMenuItem17.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem17.Size = new System.Drawing.Size(263, 6);
             // 
             // memCARDuinoMenuRead
             // 
             this.memCARDuinoMenuRead.Name = "memCARDuinoMenuRead";
-            this.memCARDuinoMenuRead.Size = new System.Drawing.Size(215, 22);
+            this.memCARDuinoMenuRead.Size = new System.Drawing.Size(266, 22);
             this.memCARDuinoMenuRead.Text = "MemCARDuino";
             this.memCARDuinoMenuRead.Click += new System.EventHandler(this.memCARDuinoMenuRead_Click);
             // 
             // toolStripMenuItem18
             // 
             this.toolStripMenuItem18.Name = "toolStripMenuItem18";
-            this.toolStripMenuItem18.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem18.Size = new System.Drawing.Size(263, 6);
             // 
             // pS1CardLinkMenuRead
             // 
             this.pS1CardLinkMenuRead.Name = "pS1CardLinkMenuRead";
-            this.pS1CardLinkMenuRead.Size = new System.Drawing.Size(215, 22);
+            this.pS1CardLinkMenuRead.Size = new System.Drawing.Size(266, 22);
             this.pS1CardLinkMenuRead.Text = "PS1CardLink";
             this.pS1CardLinkMenuRead.Click += new System.EventHandler(this.pS1CardLinkMenuRead_Click);
+            // 
+            // pS1CardLinkRemoteMenuRead
+            // 
+            this.pS1CardLinkRemoteMenuRead.Name = "pS1CardLinkRemoteMenuRead";
+            this.pS1CardLinkRemoteMenuRead.Size = new System.Drawing.Size(266, 22);
+            this.pS1CardLinkRemoteMenuRead.Text = "PS1CardLink (Remote Link over TCP)";
+            this.pS1CardLinkRemoteMenuRead.Click += new System.EventHandler(this.pS1CardLinkRemoteMenuRead_Click);
             // 
             // toolStripMenuItem16
             // 
             this.toolStripMenuItem16.Name = "toolStripMenuItem16";
-            this.toolStripMenuItem16.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem16.Size = new System.Drawing.Size(263, 6);
             // 
             // pS3MemoryCardAdaptorMenuRead
             // 
             this.pS3MemoryCardAdaptorMenuRead.Name = "pS3MemoryCardAdaptorMenuRead";
-            this.pS3MemoryCardAdaptorMenuRead.Size = new System.Drawing.Size(215, 22);
+            this.pS3MemoryCardAdaptorMenuRead.Size = new System.Drawing.Size(266, 22);
             this.pS3MemoryCardAdaptorMenuRead.Text = "PS3 Memory Card Adaptor";
             this.pS3MemoryCardAdaptorMenuRead.Click += new System.EventHandler(this.pS3MemoryCardAdaptorMenuRead_Click);
             // 
@@ -467,59 +478,60 @@
             this.memCARDuinoMenuWrite,
             this.toolStripMenuItem19,
             this.pS1CardLinkMenuWrite,
+            this.pS1CardLinkRemoteMenuWrite,
             this.toolStripMenuItem22,
             this.pS3MemoryCardAdaptorMenuWrite});
             this.writeToToolStripMenuItem.Name = "writeToToolStripMenuItem";
-            this.writeToToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.writeToToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.writeToToolStripMenuItem.Text = "Write save data";
             // 
             // dexDriveMenuWrite
             // 
             this.dexDriveMenuWrite.Name = "dexDriveMenuWrite";
-            this.dexDriveMenuWrite.Size = new System.Drawing.Size(215, 22);
+            this.dexDriveMenuWrite.Size = new System.Drawing.Size(266, 22);
             this.dexDriveMenuWrite.Text = "DexDrive";
             this.dexDriveMenuWrite.Click += new System.EventHandler(this.dexDriveMenuWrite_Click);
             // 
             // toolStripMenuItem12
             // 
             this.toolStripMenuItem12.Name = "toolStripMenuItem12";
-            this.toolStripMenuItem12.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem12.Size = new System.Drawing.Size(263, 6);
             // 
             // memCARDuinoMenuWrite
             // 
             this.memCARDuinoMenuWrite.Name = "memCARDuinoMenuWrite";
-            this.memCARDuinoMenuWrite.Size = new System.Drawing.Size(215, 22);
+            this.memCARDuinoMenuWrite.Size = new System.Drawing.Size(266, 22);
             this.memCARDuinoMenuWrite.Text = "MemCARDuino";
             this.memCARDuinoMenuWrite.Click += new System.EventHandler(this.memCARDuinoMenuWrite_Click);
             // 
             // toolStripMenuItem19
             // 
             this.toolStripMenuItem19.Name = "toolStripMenuItem19";
-            this.toolStripMenuItem19.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem19.Size = new System.Drawing.Size(263, 6);
             // 
             // pS1CardLinkMenuWrite
             // 
             this.pS1CardLinkMenuWrite.Name = "pS1CardLinkMenuWrite";
-            this.pS1CardLinkMenuWrite.Size = new System.Drawing.Size(215, 22);
+            this.pS1CardLinkMenuWrite.Size = new System.Drawing.Size(266, 22);
             this.pS1CardLinkMenuWrite.Text = "PS1CardLink";
             this.pS1CardLinkMenuWrite.Click += new System.EventHandler(this.pS1CardLinkMenuWrite_Click);
             // 
             // toolStripMenuItem22
             // 
             this.toolStripMenuItem22.Name = "toolStripMenuItem22";
-            this.toolStripMenuItem22.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem22.Size = new System.Drawing.Size(263, 6);
             // 
             // pS3MemoryCardAdaptorMenuWrite
             // 
             this.pS3MemoryCardAdaptorMenuWrite.Name = "pS3MemoryCardAdaptorMenuWrite";
-            this.pS3MemoryCardAdaptorMenuWrite.Size = new System.Drawing.Size(215, 22);
+            this.pS3MemoryCardAdaptorMenuWrite.Size = new System.Drawing.Size(266, 22);
             this.pS3MemoryCardAdaptorMenuWrite.Text = "PS3 Memory Card Adaptor";
             this.pS3MemoryCardAdaptorMenuWrite.Click += new System.EventHandler(this.pS3MemoryCardAdaptorMenuWrite_Click);
             // 
             // toolStripMenuItem21
             // 
             this.toolStripMenuItem21.Name = "toolStripMenuItem21";
-            this.toolStripMenuItem21.Size = new System.Drawing.Size(151, 6);
+            this.toolStripMenuItem21.Size = new System.Drawing.Size(177, 6);
             // 
             // formatMemoryCardToolStripMenuItem
             // 
@@ -529,45 +541,46 @@
             this.memCARDuinoMenuFormat,
             this.toolStripMenuItem20,
             this.pS1CardLinkMenuFormat,
+            this.pS1CardLinkRemoteMenuFormat,
             this.toolStripMenuItem24,
             this.pS3MemoryCardAdaptorMenuFormat});
             this.formatMemoryCardToolStripMenuItem.Name = "formatMemoryCardToolStripMenuItem";
-            this.formatMemoryCardToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.formatMemoryCardToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.formatMemoryCardToolStripMenuItem.Text = "Format card";
             // 
             // toolStripMenuItem23
             // 
             this.toolStripMenuItem23.Name = "toolStripMenuItem23";
-            this.toolStripMenuItem23.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem23.Size = new System.Drawing.Size(263, 6);
             // 
             // memCARDuinoMenuFormat
             // 
             this.memCARDuinoMenuFormat.Name = "memCARDuinoMenuFormat";
-            this.memCARDuinoMenuFormat.Size = new System.Drawing.Size(215, 22);
+            this.memCARDuinoMenuFormat.Size = new System.Drawing.Size(266, 22);
             this.memCARDuinoMenuFormat.Text = "MemCARDuino";
             this.memCARDuinoMenuFormat.Click += new System.EventHandler(this.memCARDuinoMenuFormat_Click);
             // 
             // toolStripMenuItem20
             // 
             this.toolStripMenuItem20.Name = "toolStripMenuItem20";
-            this.toolStripMenuItem20.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem20.Size = new System.Drawing.Size(263, 6);
             // 
             // pS1CardLinkMenuFormat
             // 
             this.pS1CardLinkMenuFormat.Name = "pS1CardLinkMenuFormat";
-            this.pS1CardLinkMenuFormat.Size = new System.Drawing.Size(215, 22);
+            this.pS1CardLinkMenuFormat.Size = new System.Drawing.Size(266, 22);
             this.pS1CardLinkMenuFormat.Text = "PS1CardLink";
             this.pS1CardLinkMenuFormat.Click += new System.EventHandler(this.pS1CardLinkMenuFormat_Click);
             // 
             // toolStripMenuItem24
             // 
             this.toolStripMenuItem24.Name = "toolStripMenuItem24";
-            this.toolStripMenuItem24.Size = new System.Drawing.Size(212, 6);
+            this.toolStripMenuItem24.Size = new System.Drawing.Size(263, 6);
             // 
             // pS3MemoryCardAdaptorMenuFormat
             // 
             this.pS3MemoryCardAdaptorMenuFormat.Name = "pS3MemoryCardAdaptorMenuFormat";
-            this.pS3MemoryCardAdaptorMenuFormat.Size = new System.Drawing.Size(215, 22);
+            this.pS3MemoryCardAdaptorMenuFormat.Size = new System.Drawing.Size(266, 22);
             this.pS3MemoryCardAdaptorMenuFormat.Text = "PS3 Memory Card Adaptor";
             this.pS3MemoryCardAdaptorMenuFormat.Click += new System.EventHandler(this.pS3MemoryCardAdaptorMenuFormat_Click);
             // 
@@ -964,6 +977,20 @@
             this.openToolStripMenuItem1.Size = new System.Drawing.Size(103, 22);
             this.openToolStripMenuItem1.Text = "Open";
             // 
+            // pS1CardLinkRemoteMenuWrite
+            // 
+            this.pS1CardLinkRemoteMenuWrite.Name = "pS1CardLinkRemoteMenuWrite";
+            this.pS1CardLinkRemoteMenuWrite.Size = new System.Drawing.Size(266, 22);
+            this.pS1CardLinkRemoteMenuWrite.Text = "PS1CardLink (Remote Link over TCP)";
+            this.pS1CardLinkRemoteMenuWrite.Click += new System.EventHandler(this.pS1CardLinkRemoteMenuWrite_Click);
+            // 
+            // pS1CardLinkRemoteMenuFormat
+            // 
+            this.pS1CardLinkRemoteMenuFormat.Name = "pS1CardLinkRemoteMenuFormat";
+            this.pS1CardLinkRemoteMenuFormat.Size = new System.Drawing.Size(266, 22);
+            this.pS1CardLinkRemoteMenuFormat.Text = "PS1CardLink (Remote Link over TCP)";
+            this.pS1CardLinkRemoteMenuFormat.Click += new System.EventHandler(this.pS1CardLinkRemoteMenuFormat_Click);
+            // 
             // mainWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1098,6 +1125,9 @@
         private System.Windows.Forms.ToolStripMenuItem pS3MemoryCardAdaptorMenuWrite;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem24;
         private System.Windows.Forms.ToolStripMenuItem pS3MemoryCardAdaptorMenuFormat;
+        private System.Windows.Forms.ToolStripMenuItem pS1CardLinkRemoteMenuRead;
+        private System.Windows.Forms.ToolStripMenuItem pS1CardLinkRemoteMenuWrite;
+        private System.Windows.Forms.ToolStripMenuItem pS1CardLinkRemoteMenuFormat;
     }
 }
 

--- a/MemcardRex/GUI/mainWindow.cs
+++ b/MemcardRex/GUI/mainWindow.cs
@@ -35,9 +35,9 @@ namespace MemcardRex
         const string appDate = "Unknown";
 
 #if DEBUG
-        const string appVersion = "1.9 (Debug)";
+        const string appVersion = "1.10 (Debug)";
 #else
-        const string appVersion = "1.9";
+        const string appVersion = "1.10";
 #endif
 
         //Location of the application

--- a/MemcardRex/GUI/mainWindow.cs
+++ b/MemcardRex/GUI/mainWindow.cs
@@ -84,6 +84,28 @@ namespace MemcardRex
             public int lastExportFormat;           //Last used format to export save
             public string remoteCommunicationAddress; // Address / hostname of the remote serial bridge host
             public int remoteCommunicationPort;    // Port to open a socket for the remote serial bridge
+
+            public programSettings(int i = 0)
+            {
+                titleEncoding = 0;              
+                showListGrid = 0;               
+                iconInterpolationMode = 0;      
+                iconPropertiesSize = 0;         
+                iconBackgroundColor = 0;        
+                backupMemcards = 0;             
+                warningMessage = 0;             
+                restoreWindowPosition = 0;      
+                fixCorruptedCards = 0;          
+                glassStatusBar = 0;             
+                formatType = 0;                 
+                listFont = "";                
+                communicationPort = "";       
+                lastSaveFormat = 0;             
+                lastExportFormat = 0;       
+                // Default values for esp-link
+                remoteCommunicationAddress = "192.168.4.1";
+                remoteCommunicationPort = 23;    
+        }
         }
 
         //All program settings
@@ -245,6 +267,13 @@ namespace MemcardRex
 
                 //Apply loaded settings
                 applySettings();
+            }
+
+            if (mainSettings.remoteCommunicationAddress == null)
+            {
+                // Provide defaults for esp-link serial bridge
+                mainSettings.remoteCommunicationAddress = "192.168.4.1";
+                mainSettings.remoteCommunicationPort = 23;
             }
         }
 
@@ -2175,7 +2204,7 @@ namespace MemcardRex
         private void pS1CardLinkMenuRead_Click(object sender, EventArgs e)
         {
             //Read a Memory Card from PS1CardLink
-            byte[] tempByteArray = new cardReaderWindow().readMemoryCardPS1CLnk(this, appName, mainSettings.communicationPort);
+            byte[] tempByteArray = new cardReaderWindow().readMemoryCardPS1CLnk(this, appName, mainSettings.communicationPort, "", 0);
 
             cardReaderRead(tempByteArray);
         }
@@ -2189,7 +2218,7 @@ namespace MemcardRex
             if (PScard.Count > 0)
             {
                 //Open a DexDrive communication window
-                new cardReaderWindow().writeMemoryCardPS1CLnk(this, appName, mainSettings.communicationPort, PScard[listIndex].saveMemoryCardStream(getSettingsBool(mainSettings.fixCorruptedCards)), 1024);
+                new cardReaderWindow().writeMemoryCardPS1CLnk(this, appName, mainSettings.communicationPort, "", 0, PScard[listIndex].saveMemoryCardStream(getSettingsBool(mainSettings.fixCorruptedCards)), 1024);
             }
         }
 
@@ -2267,12 +2296,41 @@ namespace MemcardRex
                     break;
 
                 case 2:         //PS1CardLink
-                    new cardReaderWindow().writeMemoryCardPS1CLnk(this, appName, mainSettings.communicationPort, blankCard.saveMemoryCardStream(true), frameNumber);
+                    new cardReaderWindow().writeMemoryCardPS1CLnk(this, appName, mainSettings.communicationPort, "", 0, blankCard.saveMemoryCardStream(true), frameNumber);
                     break;
 
                 case 3:         //PS3 Memory Card Adaptor
                     new cardReaderWindow().writeMemoryCardPS3MCA(this, appName, mainSettings.communicationPort, blankCard.saveMemoryCardStream(true), frameNumber);
                     break;
+                case 4:         //PS1CardLink (Remote TCP)
+                    new cardReaderWindow().writeMemoryCardPS1CLnk(this, appName, "", mainSettings.remoteCommunicationAddress, mainSettings.remoteCommunicationPort, blankCard.saveMemoryCardStream(true), frameNumber);
+                    break;
+            }
+        }
+
+        private void pS1CardLinkRemoteMenuRead_Click(object sender, EventArgs e)
+        {
+            //Read a Memory Card from PS1CardLink
+            byte[] tempByteArray = new cardReaderWindow().readMemoryCardPS1CLnk(this, appName, "", mainSettings.remoteCommunicationAddress, mainSettings.remoteCommunicationPort);
+
+            cardReaderRead(tempByteArray);
+        }
+
+        private void pS1CardLinkRemoteMenuFormat_Click(object sender, EventArgs e)
+        {
+            //Format a Memory Card on PS1Link Remote
+            formatHardwareCard(4);
+        }
+
+        private void pS1CardLinkRemoteMenuWrite_Click(object sender, EventArgs e)
+        {
+            int listIndex = mainTabControl.SelectedIndex;
+
+            //Check if there are any cards to write
+            if (PScard.Count > 0)
+            {
+                //Open a DexDrive communication window
+                new cardReaderWindow().writeMemoryCardPS1CLnk(this, appName, "", mainSettings.remoteCommunicationAddress, mainSettings.remoteCommunicationPort, PScard[listIndex].saveMemoryCardStream(getSettingsBool(mainSettings.fixCorruptedCards)), 1024);
             }
         }
     }

--- a/MemcardRex/GUI/mainWindow.cs
+++ b/MemcardRex/GUI/mainWindow.cs
@@ -82,6 +82,8 @@ namespace MemcardRex
             public string communicationPort;       //Communication port for Hardware interfaces
             public int lastSaveFormat;             //Last used format to save memory card
             public int lastExportFormat;           //Last used format to export save
+            public string remoteCommunicationAddress; // Address / hostname of the remote serial bridge host
+            public int remoteCommunicationPort;    // Port to open a socket for the remote serial bridge
         }
 
         //All program settings
@@ -188,6 +190,10 @@ namespace MemcardRex
                 //Load DexDrive COM port
                 mainSettings.communicationPort = xmlAppSettings.readXmlEntry("ComPort");
 
+                // Load TCP/IP settings
+                mainSettings.remoteCommunicationAddress = xmlAppSettings.readXmlEntry("RemoteComAddress");
+                mainSettings.remoteCommunicationPort = xmlAppSettings.readXmlEntryInt("RemoteComPort", 0, 65535);
+
                 //Load Title Encoding
                 mainSettings.titleEncoding = xmlAppSettings.readXmlEntryInt("TitleEncoding", 0, 1);
 
@@ -255,6 +261,10 @@ namespace MemcardRex
 
             //Set DexDrive port
             xmlAppSettings.writeXmlEntry("ComPort", mainSettings.communicationPort);
+
+            //Set TCP/IP settings
+            xmlAppSettings.writeXmlEntry("RemoteComAddress", mainSettings.remoteCommunicationAddress);
+            xmlAppSettings.writeXmlEntry("RemoteComPort", mainSettings.remoteCommunicationPort.ToString());
 
             //Set title encoding
             xmlAppSettings.writeXmlEntry("TitleEncoding", mainSettings.titleEncoding.ToString());

--- a/MemcardRex/GUI/preferencesWindow.Designer.cs
+++ b/MemcardRex/GUI/preferencesWindow.Designer.cs
@@ -50,12 +50,17 @@
             this.backgroundCombo = new System.Windows.Forms.ComboBox();
             this.backgroundLabel = new System.Windows.Forms.Label();
             this.fixCorruptedCardsCheckbox = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.remoteAddressBox = new System.Windows.Forms.TextBox();
+            this.remotePortUpDown = new System.Windows.Forms.NumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.remotePortUpDown)).BeginInit();
             this.SuspendLayout();
             // 
             // okButton
             // 
             this.okButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.okButton.Location = new System.Drawing.Point(224, 184);
+            this.okButton.Location = new System.Drawing.Point(224, 246);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(76, 24);
             this.okButton.TabIndex = 99;
@@ -66,7 +71,7 @@
             // cancelButton
             // 
             this.cancelButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.cancelButton.Location = new System.Drawing.Point(304, 184);
+            this.cancelButton.Location = new System.Drawing.Point(304, 246);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(76, 24);
             this.cancelButton.TabIndex = 0;
@@ -77,7 +82,7 @@
             // applyButton
             // 
             this.applyButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.applyButton.Location = new System.Drawing.Point(384, 184);
+            this.applyButton.Location = new System.Drawing.Point(384, 246);
             this.applyButton.Name = "applyButton";
             this.applyButton.Size = new System.Drawing.Size(76, 24);
             this.applyButton.TabIndex = 1;
@@ -207,7 +212,7 @@
             // spacerLabel
             // 
             this.spacerLabel.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.spacerLabel.Location = new System.Drawing.Point(4, 179);
+            this.spacerLabel.Location = new System.Drawing.Point(4, 241);
             this.spacerLabel.Name = "spacerLabel";
             this.spacerLabel.Size = new System.Drawing.Size(456, 2);
             this.spacerLabel.TabIndex = 8;
@@ -275,11 +280,50 @@
             this.fixCorruptedCardsCheckbox.TabIndex = 103;
             this.fixCorruptedCardsCheckbox.Text = "Try to fix corrupted Memory Cards";
             this.fixCorruptedCardsCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(124, 182);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(69, 13);
+            this.label1.TabIndex = 105;
+            this.label1.Text = "Remote Port:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(4, 182);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(88, 13);
+            this.label2.TabIndex = 104;
+            this.label2.Text = "Remote Address:";
+            this.label2.Click += new System.EventHandler(this.label2_Click);
+            // 
+            // remoteAddressBox
+            // 
+            this.remoteAddressBox.Location = new System.Drawing.Point(7, 199);
+            this.remoteAddressBox.Name = "remoteAddressBox";
+            this.remoteAddressBox.Size = new System.Drawing.Size(113, 20);
+            this.remoteAddressBox.TabIndex = 106;
+            this.remoteAddressBox.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            // 
+            // remotePortUpDown
+            // 
+            this.remotePortUpDown.Location = new System.Drawing.Point(124, 199);
+            this.remotePortUpDown.Name = "remotePortUpDown";
+            this.remotePortUpDown.Size = new System.Drawing.Size(120, 20);
+            this.remotePortUpDown.TabIndex = 107;
+            // 
             // preferencesWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(463, 212);
+            this.ClientSize = new System.Drawing.Size(463, 279);
+            this.Controls.Add(this.remotePortUpDown);
+            this.Controls.Add(this.remoteAddressBox);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.fixCorruptedCardsCheckbox);
             this.Controls.Add(this.backgroundCombo);
             this.Controls.Add(this.backgroundLabel);
@@ -309,6 +353,7 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Preferences";
+            ((System.ComponentModel.ISupportInitialize)(this.remotePortUpDown)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -338,5 +383,9 @@
         private System.Windows.Forms.ComboBox backgroundCombo;
         private System.Windows.Forms.Label backgroundLabel;
         private System.Windows.Forms.CheckBox fixCorruptedCardsCheckbox;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox remoteAddressBox;
+        private System.Windows.Forms.NumericUpDown remotePortUpDown;
     }
 }

--- a/MemcardRex/GUI/preferencesWindow.cs
+++ b/MemcardRex/GUI/preferencesWindow.cs
@@ -39,6 +39,8 @@ namespace MemcardRex
             if (progSettings.warningMessage == 1) backupWarningCheckBox.Checked = true; else backupWarningCheckBox.Checked = false;
             if (progSettings.restoreWindowPosition == 1) restorePositionCheckbox.Checked = true; else restorePositionCheckbox.Checked = false;
             if (progSettings.fixCorruptedCards == 1) fixCorruptedCardsCheckbox.Checked = true; else fixCorruptedCardsCheckbox.Checked = false;
+            remoteAddressBox.Text = progSettings.remoteCommunicationAddress;
+            remotePortUpDown.Value = progSettings.remoteCommunicationPort;
             
 
             //Load all COM ports found on the system
@@ -74,6 +76,8 @@ namespace MemcardRex
             progSettings.iconBackgroundColor = backgroundCombo.SelectedIndex;
             progSettings.formatType = formatCombo.SelectedIndex;
             progSettings.communicationPort = SavedComPort;
+            progSettings.remoteCommunicationAddress = remoteAddressBox.Text;
+            progSettings.remoteCommunicationPort = Convert.ToUInt16(remotePortUpDown.Value);
 
             if (gridCheckbox.Checked == true) progSettings.showListGrid = 1; else progSettings.showListGrid = 0;
             if (backupCheckbox.Checked == true) progSettings.backupMemcards = 1; else progSettings.backupMemcards = 0;
@@ -106,6 +110,16 @@ namespace MemcardRex
         {
             //Save the COM port if the user selected a new one
             SavedComPort = dexDriveCombo.Text;
+        }
+
+        private void label2_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void textBox1_TextChanged(object sender, EventArgs e)
+        {
+
         }
     }
 }

--- a/MemcardRex/Hardware/CardLink.cs
+++ b/MemcardRex/Hardware/CardLink.cs
@@ -1,11 +1,13 @@
 ﻿//PS1CardLink communication class (based on MemCARDuino)
 //Shendo 2013
+//lmiori92 2021: added support for TCP communication (e.g. Serial Wifi Bridge)
 
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO.Ports;
 using System.Threading;
+using System.Net.Sockets;
 
 namespace PS1CardLinkCommunication
 {
@@ -16,22 +18,49 @@ namespace PS1CardLinkCommunication
 
         //PS1CLnk communication port
         SerialPort OpenedPort = null;
+        TcpClient OpenTcpClient = null;
+        NetworkStream TcpStream = null;
 
         //Contains a software version of a detected device
         string SoftwareVersion = "0.0";
 
+        // This constructor is used to setup a Serial Port communication with PS1Link
         public string StartPS1CardLink(string ComPortName)
         {
             //Define a port to open
             OpenedPort = new SerialPort(ComPortName, 38400, Parity.None, 8, StopBits.One);
             OpenedPort.ReadBufferSize = 256;
 
-            //Buffer for storing read data from the PS1CLnk
-            byte[] ReadData = null;
-
             //Try to open a selected port (in case of an error return a descriptive string)
             try { OpenedPort.Open(); }
             catch (Exception e) { return e.Message; }
+
+            // Initial handshake
+            return InitializePS1CardLink(ComPortName);
+        }
+
+        // This constructor is used to setup a Serial Port over TCP/IP with PS1Link
+        public string StartPS1CardLink(string Address, int Port)
+        {
+            // Try to setup the communication link
+            try
+            {
+                OpenTcpClient  = new TcpClient(Address, Port);
+                TcpStream = OpenTcpClient.GetStream();
+            }
+            catch (Exception e)
+            {
+                return e.Message;
+            }
+
+            // Initial handshake
+            return InitializePS1CardLink(Address + ":" + Port);
+        }
+
+        private string InitializePS1CardLink(string ComName)
+        {
+            //Buffer for storing read data from the PS1CLnk
+            byte[] ReadData = null;
 
             //Check if this is PS1CLnk
             SendDataToPort((byte)PS1CLnkCommands.GETID, 100);
@@ -39,7 +68,7 @@ namespace PS1CardLinkCommunication
 
             if (ReadData[0] != 'P' || ReadData[1] != 'S' || ReadData[2] != '1' || ReadData[3] != 'C' || ReadData[4] != 'L' || ReadData[5] != 'N' || ReadData[6] != 'K')
             {
-                return "PS1CardLink was not detected on '" + ComPortName + "' port.";
+                return "PS1CardLink was not detected on '" + ComName + "' port.";
             }
 
             //Get the software version
@@ -55,7 +84,15 @@ namespace PS1CardLinkCommunication
         //Cleanly stop working with PS1CLnk
         public void StopPS1CardLink()
         {
-            if (OpenedPort.IsOpen == true) OpenedPort.Close();
+            if (OpenedPort != null)
+            {
+                if (OpenedPort.IsOpen == true) OpenedPort.Close();
+            }
+            else if (TcpStream != null)
+            {
+                TcpStream.Close();
+                OpenTcpClient.Close();
+            }
         }
 
         //Get the software version of PS1CLnk
@@ -68,13 +105,30 @@ namespace PS1CardLinkCommunication
         private void SendDataToPort(byte Command, int Delay)
         {
             //Clear everything in the input buffer
-            OpenedPort.DiscardInBuffer();
+            FlushPort();
 
             //Send Command Byte
-            OpenedPort.Write(new byte[] { Command }, 0, 1);
+            SendDataToPort(new byte[] { Command }, 0, 1);
 
             //Wait for a required timeframe (for the PS1CLnk response)
             if (Delay > 0) Thread.Sleep(Delay);
+        }
+
+        // Send data to the communication port
+        private void SendDataToPort(byte[] Data, int offset, int count)
+        {
+            if (OpenedPort != null)
+            {
+                OpenedPort.Write(Data, offset, count);
+            }
+            else if (TcpStream != null)
+            {
+                TcpStream.Write(Data, offset, count);
+            }
+            else
+            {
+                // Not initialized properly
+            }
         }
 
         //Catch the response from a PS1CLnk
@@ -84,9 +138,55 @@ namespace PS1CardLinkCommunication
             byte[] InputStream = new byte[256];
 
             //Read data from PS1CLnk
-            if (OpenedPort.BytesToRead != 0) OpenedPort.Read(InputStream, 0, 256);
+            if (OpenedPort != null)
+            {
+                if (OpenedPort.BytesToRead != 0) OpenedPort.Read(InputStream, 0, 256);                
+            }
+            else if (OpenTcpClient != null)
+            {
+                if (OpenTcpClient.Available != 0)
+                {
+                    TcpStream.Read(InputStream, 0, 256);
+                }
+            }
+            else
+            {
+                // Not initialized properly
+            }
 
             return InputStream;
+        }
+
+        private int GetAvailableBytesFromPort()
+        {
+            if (OpenedPort != null)
+            {
+                return OpenedPort.BytesToRead;                
+            }
+            else if (OpenTcpClient != null)
+            {
+                return OpenTcpClient.Available;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        private void FlushPort()
+        {
+            if (OpenedPort != null)
+            {
+                OpenedPort.DiscardInBuffer();
+            }
+            else if (OpenTcpClient != null)
+            {
+                ReadDataFromPort();
+            }
+            else
+            {
+                // Not initialized properly
+            }
         }
 
         //Read a specified frame of a Memory Card
@@ -110,7 +210,7 @@ namespace PS1CardLinkCommunication
             SendDataToPort(FrameLsb, 0);
 
             //Wait for the buffer to fill
-            while (OpenedPort.BytesToRead < 130 && DelayCounter < 18)
+            while (GetAvailableBytesFromPort() < 130 && DelayCounter < 18)
             {
                 Thread.Sleep(5);
                 DelayCounter++;
@@ -152,17 +252,17 @@ namespace PS1CardLinkCommunication
                 XorData ^= FrameData[i];
             }
             
-            OpenedPort.DiscardInBuffer();
+            FlushPort();
 
             //Write a frame to the Memory Card
             SendDataToPort((byte)PS1CLnkCommands.MCW, 0);
             SendDataToPort(FrameMsb, 0);
             SendDataToPort(FrameLsb, 0);
-            OpenedPort.Write(FrameData, 0, 128);
+            SendDataToPort(FrameData, 0, 128);
             SendDataToPort(XorData, 0);                      //XOR Checksum
 
             //Wait for the buffer to fill
-            while (OpenedPort.BytesToRead < 1 && DelayCounter < 18)
+            while (GetAvailableBytesFromPort() < 1 && DelayCounter < 18)
             {
                 Thread.Sleep(5);
                 DelayCounter++;

--- a/MemcardRex/Hardware/CardLink.cs
+++ b/MemcardRex/Hardware/CardLink.cs
@@ -24,9 +24,15 @@ namespace PS1CardLinkCommunication
         //Contains a software version of a detected device
         string SoftwareVersion = "0.0";
 
+        //Protocol setup
+        int MaxTimeout5msTickCount = 18;
+
         // This constructor is used to setup a Serial Port communication with PS1Link
         public string StartPS1CardLink(string ComPortName)
         {
+            //Setup the protocol parameters
+            MaxTimeout5msTickCount = 18;  /* 5ms * 18 = 90ms */
+
             //Define a port to open
             OpenedPort = new SerialPort(ComPortName, 38400, Parity.None, 8, StopBits.One);
             OpenedPort.ReadBufferSize = 256;
@@ -42,6 +48,9 @@ namespace PS1CardLinkCommunication
         // This constructor is used to setup a Serial Port over TCP/IP with PS1Link
         public string StartPS1CardLink(string Address, int Port)
         {
+            //Setup the protocol parameters
+            MaxTimeout5msTickCount = 400;  /* 5ms * 400 = 2000ms */
+
             // Try to setup the communication link
             try
             {
@@ -61,19 +70,28 @@ namespace PS1CardLinkCommunication
         {
             //Buffer for storing read data from the PS1CLnk
             byte[] ReadData = null;
+            int ReceivedBytes = 0;
+            //Error string
+            string ErrorString = "PS1CardLink was not detected on '" + ComName + "' port.";
 
             //Check if this is PS1CLnk
             SendDataToPort((byte)PS1CLnkCommands.GETID, 100);
-            ReadData = ReadDataFromPort();
 
-            if (ReadData[0] != 'P' || ReadData[1] != 'S' || ReadData[2] != '1' || ReadData[3] != 'C' || ReadData[4] != 'L' || ReadData[5] != 'N' || ReadData[6] != 'K')
+            ReadData = ReadDataFromPort(ref ReceivedBytes);
+
+            if (ReceivedBytes != 7 || ReadData[0] != 'P' || ReadData[1] != 'S' || ReadData[2] != '1' || ReadData[3] != 'C' || ReadData[4] != 'L' || ReadData[5] != 'N' || ReadData[6] != 'K')
             {
-                return "PS1CardLink was not detected on '" + ComName + "' port.";
+                return ErrorString;
             }
 
             //Get the software version
             SendDataToPort((byte)PS1CLnkCommands.GETVER, 30);
-            ReadData = ReadDataFromPort();
+            ReadData = ReadDataFromPort(ref ReceivedBytes);
+
+            if (ReceivedBytes != 1)
+            {
+                return ErrorString;
+            }
 
             SoftwareVersion = (ReadData[0] >> 4).ToString() + "." + (ReadData[0] & 0xF).ToString();
 
@@ -132,21 +150,23 @@ namespace PS1CardLinkCommunication
         }
 
         //Catch the response from a PS1CLnk
-        private byte[] ReadDataFromPort()
+        private byte[] ReadDataFromPort(ref int BytesRead)
         {
             //Buffer for reading data
             byte[] InputStream = new byte[256];
 
+            BytesRead = 0;
+
             //Read data from PS1CLnk
             if (OpenedPort != null)
             {
-                if (OpenedPort.BytesToRead != 0) OpenedPort.Read(InputStream, 0, 256);                
+                if (OpenedPort.BytesToRead != 0) BytesRead = OpenedPort.Read(InputStream, 0, 256);                
             }
             else if (OpenTcpClient != null)
             {
                 if (OpenTcpClient.Available != 0)
                 {
-                    TcpStream.Read(InputStream, 0, 256);
+                    BytesRead = TcpStream.Read(InputStream, 0, 256);
                 }
             }
             else
@@ -173,6 +193,28 @@ namespace PS1CardLinkCommunication
             }
         }
 
+        //Await a given number of bytes to be ready within a certain time
+        private void AwaitAvailable(int BytesCount)
+        {
+            int DelayCounter = 0;
+            int PreviousAvailableBytes = 0;
+
+            while (GetAvailableBytesFromPort() < BytesCount && DelayCounter < MaxTimeout5msTickCount)
+            {
+                Thread.Sleep(5);
+                if (PreviousAvailableBytes == GetAvailableBytesFromPort())
+                {  //No data came within the timeframe, start counting the timeout
+                    DelayCounter++;
+                }
+                else
+                {  //Data came, we can reset the timeout counter
+                    DelayCounter = 0;
+                }
+                PreviousAvailableBytes = GetAvailableBytesFromPort();
+            }
+        }
+
+        //Discard all the bytes currently stored in the receive buffer of the trasport
         private void FlushPort()
         {
             if (OpenedPort != null)
@@ -181,7 +223,8 @@ namespace PS1CardLinkCommunication
             }
             else if (OpenTcpClient != null)
             {
-                ReadDataFromPort();
+                int ReceivedBytes = 0;
+                ReadDataFromPort(ref ReceivedBytes);
             }
             else
             {
@@ -192,10 +235,9 @@ namespace PS1CardLinkCommunication
         //Read a specified frame of a Memory Card
         public byte[] ReadMemoryCardFrame(ushort FrameNumber)
         {
-            int DelayCounter = 0;
-
             //Buffer for storing read data from PS1CLnk
             byte[] ReadData = null;
+            int ReceivedBytes = 0;
 
             //128 byte frame data from a Memory Card
             byte[] ReturnDataBuffer = new byte[128];
@@ -209,14 +251,14 @@ namespace PS1CardLinkCommunication
             SendDataToPort(FrameMsb, 0);
             SendDataToPort(FrameLsb, 0);
 
-            //Wait for the buffer to fill
-            while (GetAvailableBytesFromPort() < 130 && DelayCounter < 18)
-            {
-                Thread.Sleep(5);
-                DelayCounter++;
-            }
+            //Wait for the buffer to fill (or to timeout)
+            AwaitAvailable(130);
 
-            ReadData = ReadDataFromPort();
+            ReadData = ReadDataFromPort(ref ReceivedBytes);
+            if (ReceivedBytes != 130)
+            {  //Unexpected amount of data has been received, refuse to continue
+                return null;
+            }
 
             //Copy recieved data
             Array.Copy(ReadData, 0, ReturnDataBuffer, 0, 128);
@@ -228,7 +270,10 @@ namespace PS1CardLinkCommunication
             }
 
             //Return null if there is a checksum missmatch
-            if (XorData != ReadData[128] || ReadData[129] != (byte)PS1CLnkResponses.GOOD) return null;
+            if (XorData != ReadData[128] || ReadData[129] != (byte)PS1CLnkResponses.GOOD)
+            {
+                return null;
+            }
 
             //Return read data
             return ReturnDataBuffer;
@@ -237,8 +282,6 @@ namespace PS1CardLinkCommunication
         //Write a specified frame to a Memory Card
         public bool WriteMemoryCardFrame(ushort FrameNumber, byte[] FrameData)
         {
-            int DelayCounter = 0;
-
             //Buffer for storing read data from PS1CLnk
             byte[] ReadData = null;
 
@@ -261,17 +304,14 @@ namespace PS1CardLinkCommunication
             SendDataToPort(FrameData, 0, 128);
             SendDataToPort(XorData, 0);                      //XOR Checksum
 
-            //Wait for the buffer to fill
-            while (GetAvailableBytesFromPort() < 1 && DelayCounter < 18)
-            {
-                Thread.Sleep(5);
-                DelayCounter++;
-            }
+            //Wait for the buffer to fill (or to timeout)
+            AwaitAvailable(1);
 
             //Fetch PS1CLnk's response to the last command
-            ReadData = ReadDataFromPort();
+            int ReceivedBytes = 0;
+            ReadData = ReadDataFromPort(ref ReceivedBytes);
 
-            if (ReadData[0x0] == (byte)PS1CLnkResponses.GOOD) return true;
+            if (ReceivedBytes == 1 && ReadData[0x0] == (byte)PS1CLnkResponses.GOOD) return true;
 
             //Data was not written sucessfully
             return false;

--- a/MemcardRex/Properties/AssemblyInfo.cs
+++ b/MemcardRex/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.0.0")]
-[assembly: AssemblyFileVersion("1.9.0.0")]
+[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To select a COM port DexDrive is connected to go to "Options"->"Preferences".
 With it your console becomes a Memory Card reader similar to the DexDrive and MemCARDuino.
 
 MemcardRex can also talk to the serial port remotely by using a Serial Port Bridge like [esp-link](https://github.com/jeelabs/esp-link).
-It conveniently fits a PSOne which has otherwise no external hardware ports.
+It conveniently fits into a PSOne which has otherwise no external hardware ports.
 
 <b>4. PS3 Memory Card Adaptor</b>
 <br>The PS3 Memory Card Adaptor is an official Sony USB adapter that allows reading and writing PS1 Memory Cards on a PlayStation 3.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ To select a COM port DexDrive is connected to go to "Options"->"Preferences".
 
 With it your console becomes a Memory Card reader similar to the DexDrive and MemCARDuino.
 
+MemcardRex can also talk to the serial port remotely by using a Serial Port Bridge like [esp-link](https://github.com/jeelabs/esp-link).
+It conveniently fits a PSOne which has otherwise no external hardware ports.
+
 <b>4. PS3 Memory Card Adaptor</b>
 <br>The PS3 Memory Card Adaptor is an official Sony USB adapter that allows reading and writing PS1 Memory Cards on a PlayStation 3.
 <br>To use it on a Windows PC, a custom USB driver needs to be installed.


### PR DESCRIPTION
This PR implements the feature described here:
https://github.com/ShendoXT/memcardrex/issues/26

Major changes:
- CardLink driver can support the serial port and serial port over TCP via a socket (actually, any raw socket communication can work).
- Some methods re-organized and created to avoid code duplication and manage the two available transport methods
- Revised timeout method that did not properly work for the wi-fi connectivity (much higher latency and more random)

Minor changes:
- added code to check that the received data chunk matches the expected number of bytes, otherwise some failure could go unnoticed.
- update some UI parts and Settings to accomodate for 2 new parameters, that is the "Hostname" and the "Port" for esp-link (or similar) connection setup

Notes
- I have no serial port at hand so I cannot currently test the serial port logic for regressions. Best effort to keep it working but not guaranteed :D Someone has to do some read/write/format testing.
- transfer speed is around 2 minutes per read/write/format operation. Not sure if the serial port is a bit faster, but I immagine it is. I don't know the details implementation of esp-link thus I can just assume the TCP packets are not always carrying a good amount of bytes thus increasing the overhead. Not a problem, really.

Any comment is welcome @ShendoXT ! 