### PR TITLE
Fix PS1 PSV header save size

### DIFF
--- a/MemcardRex.Core/ps1card.cs
+++ b/MemcardRex.Core/ps1card.cs
@@ -502,12 +502,12 @@ namespace MemcardRex.Core
             psvSave[0x3C] = 1;
             psvSave[0x44] = 0x84;
             psvSave[0x49] = 2;
-            psvSave[0x5D] = 0x20;
             psvSave[0x60] = 3;
             psvSave[0x61] = 0x90;
 
             Array.Copy(save, 0x0A, psvSave, 0x64, 0x20);
             Array.Copy(BitConverter.GetBytes(save.Length - 0x80), 0, psvSave, 0x40, 4);
+            Array.Copy(BitConverter.GetBytes(save.Length - 0x80), 0, psvSave, 0x5C, 4);
             Array.Copy(save, 0x80, psvSave, 0x84, save.Length - 0x80);
 
             using (SHA1 sha = SHA1.Create())


### PR DESCRIPTION
Just a minor fix related to PSV files, as this can generate problems when importing to PS3 consoles.

The PSV header for PS1 saves actually keeps the save-size value in two offsets. (0x40 and 0x5C)

As an example, I'm attaching a PSV file generated by original PS3 hardware, with a save that uses 2 blocks. The header has `0x4000` size value on both 0x40 and 0x5C offsets.

[final-fantasy-chronicles.16822(1).zip](https://github.com/user-attachments/files/17530959/final-fantasy-chronicles.16822.1.zip)

Thanks for your great MemcardRex tool! 👍 