### PR TITLE
Add MiSTer FPGA PSX Core Memory Card file types to the list of supported files to open.

### DIFF
--- a/MemcardRex.Windows/Windows/GUI/mainWindow.cs
+++ b/MemcardRex.Windows/Windows/GUI/mainWindow.cs
@@ -91,8 +91,8 @@ namespace MemcardRex
         string tempBufferName = null;
 
         //Supported Memory Card extensions
-        private const string mcSupportedExtensions = "All supported|*.bin;*.ddf;*.gme;*.mc;*.mcd;*.mci;*.mcr;*.mem;*.ps;*.psm;*.srm;*.vgs;*.vm1;*.vmp;*.vmc;*.sav";
-        private const string mcExtensions = "Standard Memory Card|*.mcr;*.bin;*.ddf;*.mc;*.mcd;*.mci;*.ps;*.psm;*.srm;*.vm1;*.vmc;|PSP/Vita Memory Card|*.VMP|PS Vita \"MCX\" PocketStation Memory Card|*.BIN|DexDrive Memory Card|*.gme|MiSTer FPGA (PSX Core) Memory Card|*.sav|VGS Memory Card|*.mem;*.vgs";
+        private const string mcSupportedExtensions = "All supported|*.bin;*.ddf;*.gme;*.mc;*.mcd;*.mci;*.mcr;*.mem;*.ps;*.psm;*.srm;*.vgs;*.vm1;*.vmp;*.vmc;*.sav;";
+        private const string mcExtensions = "Standard Memory Card|*.mcr;*.bin;*.ddf;*.mc;*.mcd;*.mci;*.ps;*.psm;*.srm;*.vm1;*.vmc;*.sav|PSP/Vita Memory Card|*.VMP|PS Vita \"MCX\" PocketStation Memory Card|*.BIN|DexDrive Memory Card|*.gme|VGS Memory Card|*.mem;*.vgs";
 
         //Supported single save extensions
         private const string ssSupportedExtensions = "All supported|*.mcs;*.ps1;*.PSV;*.mcb;*.mcx;*.pda;*.psx;B???????????*";

--- a/MemcardRex.Windows/Windows/GUI/mainWindow.cs
+++ b/MemcardRex.Windows/Windows/GUI/mainWindow.cs
@@ -91,8 +91,8 @@ namespace MemcardRex
         string tempBufferName = null;
 
         //Supported Memory Card extensions
-        private const string mcSupportedExtensions = "All supported|*.bin;*.ddf;*.gme;*.mc;*.mcd;*.mci;*.mcr;*.mem;*.ps;*.psm;*.srm;*.vgs;*.vm1;*.vmp;*.vmc";
-        private const string mcExtensions = "Standard Memory Card|*.mcr;*.bin;*.ddf;*.mc;*.mcd;*.mci;*.ps;*.psm;*.srm;*.vm1;*.vmc|PSP/Vita Memory Card|*.VMP|PS Vita \"MCX\" PocketStation Memory Card|*.BIN|DexDrive Memory Card|*.gme|VGS Memory Card|*.mem;*.vgs";
+        private const string mcSupportedExtensions = "All supported|*.bin;*.ddf;*.gme;*.mc;*.mcd;*.mci;*.mcr;*.mem;*.ps;*.psm;*.srm;*.vgs;*.vm1;*.vmp;*.vmc;*.sav";
+        private const string mcExtensions = "Standard Memory Card|*.mcr;*.bin;*.ddf;*.mc;*.mcd;*.mci;*.ps;*.psm;*.srm;*.vm1;*.vmc;|PSP/Vita Memory Card|*.VMP|PS Vita \"MCX\" PocketStation Memory Card|*.BIN|DexDrive Memory Card|*.gme|MiSTer FPGA (PSX Core) Memory Card|*.sav|VGS Memory Card|*.mem;*.vgs";
 
         //Supported single save extensions
         private const string ssSupportedExtensions = "All supported|*.mcs;*.ps1;*.PSV;*.mcb;*.mcx;*.pda;*.psx;B???????????*";

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 * PS3 virtual Memory Card(*.VM1)
 * PS Vita "MCX" PocketStation Memory Card(*.BIN)
 * POPStarter Virtual Memory Card(*.VMC)
+* MiSTer FPGA (PSX Core) Memory Card(*.sav)
 
 <br>**Supported single save formats:**
 * PSXGame Edit single save(*.mcs)


### PR DESCRIPTION
MemcardRex already supports opening the Memory Card save files (*.sav) from the MiSTer FPGA PSX Core.  This minor update eliminates an extra click of switching to the "all files" option in the drop down menu when opening *.sav files.  This may clear up some confusion for MiSTer FPGA users who may not know MemcardRex already supports the memory card image files from MiSTer.